### PR TITLE
Fix slide template

### DIFF
--- a/.github/mcl_config.json
+++ b/.github/mcl_config.json
@@ -1,5 +1,9 @@
 {
   "aliveStatusCodes": [200, 206, 403],
-  "timeout": "3m",
-  "retryCount": 5
+  "ignorePatterns": [
+    {
+      "bazel": "^https://bazel.build",
+      "make": "^https://makefiletutorial.com"
+    }
+  ]
 }

--- a/.github/mcl_config.json
+++ b/.github/mcl_config.json
@@ -1,3 +1,5 @@
 {
-  "aliveStatusCodes": [200, 206, 403]
+  "aliveStatusCodes": [200, 206, 403],
+  "timeout": "3m",
+  "retryCount": 5
 }

--- a/lectures/associative_containers.md
+++ b/lectures/associative_containers.md
@@ -2,7 +2,7 @@
 marp: true
 math: katex
 theme: custom-theme
-footer: ![width:80px](images/C++ForYourselfIcon.png)
+paginate: true
 ---
 
 # Associative containers
@@ -13,7 +13,7 @@ footer: ![width:80px](images/C++ForYourselfIcon.png)
 - `std::set`
 - `std::unordered_set`
 
-### 📺 Watch the related [YouTube video](https://youtu.be/TCu76SYmVCg)! 
+### 📺 Watch the related [YouTube video](https://youtu.be/TCu76SYmVCg)!
 
 ---
 # Special symbols used in slides
@@ -36,7 +36,7 @@ Style (🎨) and software design (🎓) recommendations mostly come from [Google
 - Implemented _usually_ as a **Red-Black tree** (not guaranteed)
 - Key can be any type with operator `<` defined
 - By default takes two template parameters:
-  <!-- 
+  <!--
   `CPP_SETUP_START`
   #include <map>
   int main() {
@@ -49,7 +49,7 @@ Style (🎨) and software design (🎓) recommendations mostly come from [Google
   std::map<char, double> map_default{};
   ```
 - We can also use `>` operator by creating the map like this:
-  <!-- 
+  <!--
   `CPP_SETUP_START`
   #include <map>
   int main() {
@@ -62,11 +62,11 @@ Style (🎨) and software design (🎓) recommendations mostly come from [Google
   std::map<int, float, std::greater<int>> map_greater{};
   ```
 - Access, add, remove data in $\mathcal{O}(\log{}n)$
-  
+
 ---
 # Add data to `std::map`
 - We can create a map from data:
-  <!-- 
+  <!--
   `CPP_SETUP_START`
   #include <map>
   int main() {
@@ -79,7 +79,7 @@ Style (🎨) and software design (🎓) recommendations mostly come from [Google
   const std::map<int, double> map_explicit = {{42, 42.42}};
   ```
 - 🔼1️⃣7️⃣
-  <!-- 
+  <!--
   `CPP_SETUP_START`
   #include <map>
   int main() {
@@ -102,8 +102,8 @@ Style (🎨) and software design (🎓) recommendations mostly come from [Google
 - Erase key: `my_map.erase(key);`
 
 ---
-
 # Example using `std::map`
+<!-- _class: center_code -->
 ```cpp
 #include <iostream>
 #include <map>
@@ -146,8 +146,7 @@ int main() {
   - Elements of `map2` not in `map1` are added to `map1`
   - Elements of `map2` with keys already in `map1` are ignored
 - Works for both: `std::map` and `std::unordered_map`:
-- 
-  <!-- 
+  <!--
   `CPP_SETUP_START`
   #include <string>
   #include <map>
@@ -164,7 +163,7 @@ int main() {
       {"A", 4}, {"B", 2}, {"D", 4}};
   map1.merge(map2);
   ```
-  <!-- 
+  <!--
   `CPP_SETUP_START`
   #include <string>
   #include <unordered_map>

--- a/lectures/associative_containers.md
+++ b/lectures/associative_containers.md
@@ -24,8 +24,8 @@ paginate: true
 - ❌ - Whatever is marked with this is wrong
 - 🚨 - Alert! Important information!
 - 💡 - Hint or a useful exercise
-- 🔼1️⃣7️⃣ - Holds for this version of C++(here, `17`) and **above**
-- 🔽1️⃣1️⃣ - Holds for versions **until** this one C++(here, `11`)
+- 🔼1️⃣7️⃣ - Holds for this version of C++ (here, `17`) and **above**
+- 🔽1️⃣1️⃣ - Holds for versions **until** this one C++ (here, `11`)
 
 Style (🎨) and software design (🎓) recommendations mostly come from [Google Style Sheet](https://google.github.io/styleguide/cppguide.html) and the [CppCoreGuidelines](https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines)
 

--- a/lectures/build_systems.md
+++ b/lectures/build_systems.md
@@ -2,7 +2,7 @@
 marp: true
 math: katex
 theme: custom-theme
-# paginate: true
+paginate: true
 footer: ![width:80px](images/C++ForYourselfIcon.png)
 ---
 

--- a/lectures/build_systems.md
+++ b/lectures/build_systems.md
@@ -108,7 +108,7 @@ int main() {
 - Can have many targets with many dependencies
 - If `target` **file** exists and is **not older** than its `dependencies` --- **nothing happens**!
 - :bulb: This allows us to **avoid doing the work twice**!
-- :bulb: A very good `make` tutorial is [here](https://web.archive.org/web/20230826174108/https://makefiletutorial.com/)
+- :bulb: A very good `make` tutorial is [here](https://makefiletutorial.com/)
 
 ---
 # A [`Makefile`](code/make/simple_build/Makefile) to build C++ code

--- a/lectures/cmake.md
+++ b/lectures/cmake.md
@@ -3,7 +3,7 @@ marp: true
 math: katex
 theme: custom-theme
 paginate: true
-# footer: ![width:80px](images/C++ForYourselfIcon.png)
+footer: ![width:80px](images/C++ForYourselfIcon.png)
 ---
 
 # CMake introduction
@@ -296,6 +296,7 @@ make -j8      # Run make with 8 threads
   - (generally any command that starts with `target_`)
 
 ---
+<!-- _backgroundColor: #0000 -->
 ![bg width:100%](images/follow_deer.jpg)
 
 ---
@@ -362,9 +363,8 @@ Stay tuned for the `*_test.cpp` files in a later video :wink:
   ```
 
 ---
-<!-- _paginate: false -->
 # The main `CMakeLists.txt` file
-`our_project/CMakeLists.txt`<br>
+`our_project/CMakeLists.txt`
 <!--
 `CPP_COPY_SNIPPET` our_project/CMakeLists.txt
 -->

--- a/lectures/control_structures.md
+++ b/lectures/control_structures.md
@@ -2,6 +2,7 @@
 marp: true
 math: katex
 theme: custom-theme
+paginate: true
 footer: ![width:80px](images/C++ForYourselfIcon.png)
 ---
 
@@ -11,7 +12,7 @@ footer: ![width:80px](images/C++ForYourselfIcon.png)
 - `if` statements and ternary operator
 - Loops: `for` and `while`
 
-### 📺 Watch the related [YouTube video](https://youtu.be/jzgTxosgGIA)! 
+### 📺 Watch the related [YouTube video](https://youtu.be/jzgTxosgGIA)!
 
 ---
 # Special symbols used in slides
@@ -55,9 +56,9 @@ if (STATEMENT) {
 - 💡 Curly brackets can be omitted for single-line statements
   <!--
   `CPP_SETUP_START`
-  
+
   inline void DoThis(){}
-  
+
   int main() {
     bool STATEMENT{};
     $PLACEHOLDER
@@ -91,7 +92,7 @@ if (STATEMENT) {
   ```cpp
   bool condition = GetRandomTrueOrFalse();
   condition ? CallIfTrue() : CallIfFalse();
-  ``` 
+  ```
 - This is **equivalent** to the following `if` statement:
   <!--
   `CPP_SETUP_START`
@@ -276,7 +277,7 @@ for (int i = 0; i < kIterationCount; ++i) {
 
 ---
 # 🔼1️⃣1️⃣ Range for loop
-- ✅ Iterate over a standard containers with simpler syntax: 
+- ✅ Iterate over a standard containers with simpler syntax:
   `std::array`, `std::vector`, or even `std::map`, *etc*.
 - Allows us to avoid mistakes with indices and shows intent
   <!--
@@ -351,7 +352,7 @@ for (int i = 0; i < kIterationCount; ++i) {
     // Do this forever
   }
   ```
-  
+
 
 ---
 # Exit loops and iterations

--- a/lectures/cpp_basic_types_and_variables.md
+++ b/lectures/cpp_basic_types_and_variables.md
@@ -3,7 +3,7 @@ marp: true
 math: katex
 theme: custom-theme
 footer: ![width:80px](images/C++ForYourselfIcon.png)
-
+paginate: true
 ---
 
 # Basics of C++
@@ -14,7 +14,7 @@ footer: ![width:80px](images/C++ForYourselfIcon.png)
 - `const`, `constexpr`
 - References
 
-#### 📺 Watch the related [YouTube video](https://youtu.be/0z0gvv_Tb_U)! 
+#### 📺 Watch the related [YouTube video](https://youtu.be/0z0gvv_Tb_U)!
 
 ---
 # Prerequisites:
@@ -128,7 +128,7 @@ unsigned long explicit_copy = number; // This works too!
 # Difference between integer types
 - The difference is in the range of representable values
 - We will talk about this later in the course
-- We can get the range for any type `T`: 
+- We can get the range for any type `T`:
   - `std::numeric_limits<T>::min()` - minimum value
   - `std::numeric_limits<T>::max()` - maximum value
   - they live in the `<limits>` header
@@ -140,7 +140,7 @@ unsigned long explicit_copy = number; // This works too!
 int main() {
   std::printf("Min: %d, max: %d\n",
          std::numeric_limits<int>::min(),
-         std::numeric_limits<int>::max());                   
+         std::numeric_limits<int>::max());
   return 0;
 }
 ```
@@ -251,47 +251,47 @@ Here is a rule of thumb to tell them apart :+1:
 - Can be used for constants created at **run time**
 - Can be initialized with **any** provided value
 - _Sometimes_ will be available at compile time
-<!--
-`CPP_SETUP_START`
-int main() {
-  $PLACEHOLDER
-  return 0;
-}
-`CPP_SETUP_END`
--->
-```cpp
-int a = 42;
-const int b = a;    // ✅
-const int c = 23;   // ✅
-const int d = c;    // ✅
-const auto e = c;   // ✅
-```
+  <!--
+  `CPP_SETUP_START`
+  int main() {
+    $PLACEHOLDER
+    return 0;
+  }
+  `CPP_SETUP_END`
+  -->
+  ```cpp
+  int a = 42;
+  const int b = a;    // ✅
+  const int c = 23;   // ✅
+  const int d = c;    // ✅
+  const auto e = c;   // ✅
+  ```
 
 </div>
 
 <div>
 
 ### `constexpr`
-- Can only be used for constants created at 
+- Can only be used for constants created at
   **compile time**
 - Can only be initialized from a `constexpr` value
+  <!--
+  `CPP_SKIP_SNIPPET`
+  -->
+  ```cpp
+  int a = 42;
+  const int a_const = 42;
+  constexpr int b = a;        // ❌
+  constexpr int c = a_const;  // ❌
+  constexpr int d = 23;       // ✅
+  constexpr int e = d;        // ✅
+  constexpr auto f = d;       // ✅
+  ```
+
+</div>
+</div>
+
 <!--
-`CPP_SKIP_SNIPPET`
--->
-```cpp
-int a = 42;
-const int a_const = 42;
-constexpr int b = a;        // ❌
-constexpr int c = a_const;  // ❌
-constexpr int d = 23;       // ✅
-constexpr int e = d;        // ✅
-constexpr auto f = d;       // ✅
-```
-
-</div>
-</div>
-
-<!-- 
 - Run time means whatever happens since we started the program
 - Compile time means whatever happens while the program is compiling
 - Computation happens at compile time and the result is stored to a variable
@@ -346,7 +346,7 @@ There are some exemptions from this rule, but it mostly works
 #include <cstdio>
 
 int main() {
-  int number = 42;  
+  int number = 42;
   int& ref = number; // Name has to fit on the slides ¯\_(ツ)_/¯
   const int& const_ref = number;
   std::printf("ref: %d, const_ref: %d\n", ref, const_ref);
@@ -385,30 +385,30 @@ int main() {  // Start of main scope
 
 # Naming of constants
 - 🎨 Name constants in the **global scope** in `CamelCase` starting with a small letter `k`:
-<!--
-`CPP_SETUP_START`
-int main() {
-  $PLACEHOLDER
-  return 0;
-}
-`CPP_SETUP_END`
--->
-```cpp
-constexpr float kImportantFloat = 42.42f;
-const int kHello{42};
-```
+  <!--
+  `CPP_SETUP_START`
+  int main() {
+    $PLACEHOLDER
+    return 0;
+  }
+  `CPP_SETUP_END`
+  -->
+  ```cpp
+  constexpr float kImportantFloat = 42.42f;
+  const int kHello{42};
+  ```
 - 🎨 Name constants in any **local scope** in `snake_case`
-<!--
-`CPP_SETUP_START`
-int main() {
-  $PLACEHOLDER
-  return 0;
-}
-`CPP_SETUP_END`
--->
-```cpp
-const auto local_scope_constant{42UL};
-```
+  <!--
+  `CPP_SETUP_START`
+  int main() {
+    $PLACEHOLDER
+    return 0;
+  }
+  `CPP_SETUP_END`
+  -->
+  ```cpp
+  const auto local_scope_constant{42UL};
+  ```
 - Keyword `const` is part of the variable's type:
   variable `kHello` above has type `const int`
 

--- a/lectures/functions.md
+++ b/lectures/functions.md
@@ -15,7 +15,7 @@ paginate: true
 - Overloading
 - Using default arguments
 
-### 📺 Watch the related [YouTube video](https://youtu.be/RaSw0g2aPig)! 
+### 📺 Watch the related [YouTube video](https://youtu.be/RaSw0g2aPig)!
 
 ---
 # Special symbols used in slides
@@ -100,16 +100,16 @@ Style (🎨) and software design (🎓) recommendations mostly come from [Google
 # ✅ Use `[[nodiscard]]` attribute
 - 🔼1️⃣7️⃣ You can use it like this:
   ```cpp
-  [[nodiscard]] double SquareNumber(double input) { 
-    return input * input; 
+  [[nodiscard]] double SquareNumber(double input) {
+    return input * input;
   }
   int main() { SquareNumber(42.0); }  // ❌ generates warning
   ```
 - Forces the output of the function to actually be used
 - When we compile the above we get:
   ```css
-  λ › c++ -std=c++17 -O3 -o test test.cpp  
-  test.cpp:3:14: warning: ignoring return value of function 
+  λ › c++ -std=c++17 -O3 -o test test.cpp
+  test.cpp:3:14: warning: ignoring return value of function
   declared with 'nodiscard' attribute [-Wunused-result]
   int main() { SquareNumber(2.0); }
               ^~~~~~ ~~~
@@ -118,8 +118,8 @@ Style (🎨) and software design (🎓) recommendations mostly come from [Google
 - No warning if result is actually used:
   <!--
   `CPP_SETUP_START`
-  [[nodiscard]] double SquareNumber(double input) { 
-    return input * input; 
+  [[nodiscard]] double SquareNumber(double input) {
+    return input * input;
   }
   int main() {
     $PLACEHOLDER
@@ -138,7 +138,7 @@ Style (🎨) and software design (🎓) recommendations mostly come from [Google
 #include <vector>
 using std::vector;
 
-[[nodiscard]] vector<int> 
+[[nodiscard]] vector<int>
 CreateFibonacciSequence(std::size_t length) {
   // Vector of size `length`, filled with 1s.
   vector<int> result(length, 1);
@@ -208,7 +208,7 @@ int main() {
     cout << "Did you expect anything useful from it?";
   }
   ```
-- The name, the argument types (including `&`, `const` etc.) 
+- The name, the argument types (including `&`, `const` etc.)
   and the return type have to be **exactly** the same
 
 ---
@@ -244,7 +244,7 @@ int main() {
 ### Pass by reference:
 - `void Fill(Cup &cup);`
 - The object that `cup` references is full afterwards
-  
+
 </div>
 
 <div>
@@ -253,7 +253,7 @@ int main() {
 - `void Fill(Cup cup);`
 - A **copy** `cup` of the original object is full
 - The original is still empty
-  
+
 </div>
 </div>
 
@@ -297,7 +297,7 @@ void DoSmthWithRef(hello) {
   hello.clear();
 }
 ```
-  
+
 </div>
 </div>
 
@@ -325,7 +325,7 @@ void DoSmthWithRef(hello) {
 - 🔼1️⃣1️⃣ Returning an object from function is **mostly** fast
 - 🔼1️⃣7️⃣ Returning an object from function is **always** fast
 - 🎓🎨 Avoid using non-`const` references, see [Google style](https://google.github.io/styleguide/cppguide.html#Inputs_and_Outputs)
-- 💡 Sometimes passing by non-const reference is still faster than returning an object from a function 
+- 💡 Sometimes passing by non-const reference is still faster than returning an object from a function
   **Measure before doing this!**
 
 ---

--- a/lectures/googletest.md
+++ b/lectures/googletest.md
@@ -1,10 +1,22 @@
-# [Introduction to testing with googletest](https://youtu.be/pxJoVRfpRPE)
+**Introduction to testing with googletest**
 
 <p align="center">
-  <a href="https://youtu.be/pxJoVRfpRPE"><img src="https://img.youtube.com/vi/pxJoVRfpRPE/0.jpg" alt="Video" align="right" width=50%></a>
+  <a href="https://youtu.be/pxJoVRfpRPE"><img src="https://img.youtube.com/vi/pxJoVRfpRPE/maxresdefault.jpg" alt="Video" align="right" width=50%></a>
 </p>
 
-## Why you should care about testing
+- [What does "testing" even mean](#what-does-testing-even-mean)
+- [The usual automated testing frameworks](#the-usual-automated-testing-frameworks)
+  - [How to get the googletest code](#how-to-get-the-googletest-code)
+  - [How to include googletest in our CMake project](#how-to-include-googletest-in-our-cmake-project)
+  - [How to use the googletest framework](#how-to-use-the-googletest-framework)
+  - [How to write your first test](#how-to-write-your-first-test)
+  - [How to run a Google test?](#how-to-run-a-google-test)
+  - [Testing our own libraries](#testing-our-own-libraries)
+- [How to keep googletest in our project codebase correctly?](#how-to-keep-googletest-in-our-project-codebase-correctly)
+  - [Update the submodules automagically](#update-the-submodules-automagically)
+- [Conclusion](#conclusion)
+
+
 
 <!-- Talking head -->
 You already know how to write some C++ code. Furthermore, you also know that the code should be structured into bite-sized chunks and that you can write functions that you can put into libraries.

--- a/lectures/headers_and_libraries.md
+++ b/lectures/headers_and_libraries.md
@@ -15,7 +15,7 @@ footer: ![width:80px](images/C++ForYourselfIcon.png)
 - When to use the keyword `inline`
 - Some common best practices
 
-### 📺 Watch the related [YouTube video](https://youtu.be/Lxo8ftglwXE)! 
+### 📺 Watch the related [YouTube video](https://youtu.be/Lxo8ftglwXE)!
 
 ---
 # Special symbols used in slides
@@ -41,7 +41,7 @@ Let's say we implement a new machine learning framework :wink:
 #include <vector>
 #include <iostream>
 
-[[nodiscard]] int 
+[[nodiscard]] int
 PredictNumber(const std::vector<int>& numbers) {
   // Arbitrarily complex code goes here.
   if (numbers.empty()) { return 0; }
@@ -123,13 +123,13 @@ $PLACEHOLDER
 `CPP_RUN_CMD` CWD:ml c++ -std=c++17 -I . main_houses.cpp
 -->
 ```cpp
-#include <ml.h>  
+#include <ml.h>
 #include <iostream>
 int main() {
-  const auto prices = 
+  const auto prices =
     MagicallyGetHousePrices();
-  std::cout 
-    << "Upcoming price: " 
+  std::cout
+    << "Upcoming price: "
     << PredictNumber(prices);
   return 0;
 }
@@ -151,13 +151,13 @@ $PLACEHOLDER
 `CPP_RUN_CMD` CWD:ml c++ -std=c++17 -I . main_bitcoin.cpp
 -->
 ```cpp
-#include <ml.h>  
+#include <ml.h>
 #include <iostream>
 int main() {
-  const auto prices = 
+  const auto prices =
     MagicallyGetBitcoinPrices();
-  std::cout 
-    << "Upcoming price: " 
+  std::cout
+    << "Upcoming price: "
     << PredictNumber(prices);
   return 0;
 }
@@ -165,7 +165,7 @@ int main() {
 
 </div>
 </div>
-  
+
 ---
 # Yay! A header-only library! :tada:
 - All functions are implemented in header files (`.h`, `.hpp`)
@@ -188,7 +188,7 @@ int main() {
 # What's `#pragma once`?
 - A **preprocessor directive** that ensures the header in which it is written is only included once
 - There are compilers that don't support it, but most do
-- Alternative --- **include guards** 
+- Alternative --- **include guards**
   For file `file.h` in `folder/` they can be:<br>
   <!--
   `CPP_SKIP_SNIPPET`
@@ -221,7 +221,7 @@ int main() {
 ```cpp
 #pragma once
 #include <vector>
-[[nodiscard]] int 
+[[nodiscard]] int
 PredictNumber(const std::vector<int>& numbers);
 ```
 
@@ -236,7 +236,7 @@ $PLACEHOLDER
 ```cpp
 #include <ml.h>
 #include <vector>
-[[nodiscard]] int 
+[[nodiscard]] int
 PredictNumber(const std::vector<int>& numbers) {
   // Compute next number (skipped to fit on the slide)
   return next_number;
@@ -277,7 +277,7 @@ c++ -std=c++17 predict_prices.cpp -I . -o predict_prices
 ```css
 Undefined symbols for architecture arm64:
   "PredictNumber(
-    std::__1::vector<int, std::__1::allocator<int> > const&)", 
+    std::__1::vector<int, std::__1::allocator<int> > const&)",
     referenced from: _main in predict_prices-066946.o
 ld: symbol(s) not found for architecture arm64
 clang: error: linker command failed with exit code 1
@@ -305,9 +305,9 @@ c++ -std=c++17 -I . ml.cpp predict_prices.cpp
   c++ -std=c++17 -c ml.cpp -I includes -o ml_static.o
   ```
   ```cmd
-  c++ -std=c++17 -c -fPIC ml.cpp -I includes -o ml_dynamic.o 
+  c++ -std=c++17 -c -fPIC ml.cpp -I includes -o ml_dynamic.o
   ```
-  <br>Assuming that all includes live in the `includes` folder,
+  Assuming that all includes live in the `includes` folder,
   results in `*.o` binary files that an OS can read and interpret
 - Pack objects into **libraries:**
   - **Static** libraries (`*.a`) are just archives of object files
@@ -441,7 +441,7 @@ void Bar() {
 </div>
 
 ---
-# But.. why?
+# But... why?
 - Linker failed because we violated **ODR** --- [**O**ne **D**efinition **R**ule](https://en.cppreference.com/w/cpp/language/definition)
 - It states that there must be **exactly one** definition of every symbol in the program, i.e., your **functions** and **variables**
 - We have two libraries `libfoo.a` and `libbar.a` with source files that both include the `print.h` and therefore have a **definition** of the `Print(...)` function
@@ -457,7 +457,7 @@ void Bar() {
   -->
   ```cpp
   #include <iostream>
-  inline void 
+  inline void
   Print(const std::string& str) { std::cout << str << "\n"; }
   ```
 - 🚨 `inline` can only be used in function **definition**
@@ -522,7 +522,7 @@ int main() {
 <div>
 
 #### Output of `./main`?
-  
+
 <div data-marpit-fragment>
 
 ```
@@ -565,7 +565,7 @@ c++ -std=c++17 main.cpp -L . -I . -lfoo -lbar -o main
 # How to avoid errors?
 - Don't use `inline` in source files
 - ✅ Always use `inline` if you **define** functions in headers
-- ✅ Do the same for constants 🔼1️⃣7️⃣ 
+- ✅ Do the same for constants 🔼1️⃣7️⃣
   ```c++
   inline constexpr auto kConst = 42;
   ```
@@ -625,7 +625,7 @@ void Bar() { Print(); }
 
 ![bg](https://fakeimg.pl/1280x1024/226699/fff/?text=Good%20luck!&font=bebas)
 
-<!-- 
+<!--
 Great article: https://jm4r.github.io/Inline/
 
 ELF: https://stackoverflow.com/questions/41879433/file-format-differences-between-a-static-library-a-and-a-shared-library-so -->

--- a/lectures/hello_world_dissection.md
+++ b/lectures/hello_world_dissection.md
@@ -35,10 +35,10 @@ Hello World!
 - [Functions](hello_world_dissection.md#functions-elevator-pitch) like `puts` and `main`
 
 ## Let's dig into all of these!
-## 📺 Watch the related [YouTube video](https://youtu.be/t2h1geGSww4)! 
+## 📺 Watch the related [YouTube video](https://youtu.be/t2h1geGSww4)!
 
 ---
-# Some words and symbols are more special than other 🦄
+# Some words and symbols are more special🦄 than other
 - In the code above, some words and symbols are highlighted
 - This is done by **parsing** the language into meaningful parts
 - Whitespaces and symbols **separate** these parts
@@ -92,7 +92,7 @@ return 0;}
 
 ```C++
 #include <stdio.h>
-int main() 
+int main()
 {puts(
              "Hello 🌍!"
     );
@@ -120,7 +120,7 @@ return
 
 # Use clang-format tool to deal with this madness!
 
-- 🤬 People tend to argue (a lot!) about how to style their code 
+- 🤬 People tend to argue (a lot!) about how to style their code
 - 💡 Avoid long discussions by using a tool `clang-format`!
 
 #### To style the `hello.cpp` do the following:
@@ -138,7 +138,7 @@ Just put a `.clang-format` file into a directory up the tree from your source fi
 
 # A "good" clang-format config
 
-- 🤔 Different people will have different opinions here 
+- 🤔 Different people will have different opinions here
 - ✅ This is the `.clang-format` file I use for my projects:
 ```yaml
 ---
@@ -154,7 +154,7 @@ BinPackParameters: false
 ...
 ```
 
-- 🤝 The most important thing is to have **a** format file in the project, regardless of which style it enforces 
+- 🤝 The most important thing is to have **a** format file in the project, regardless of which style it enforces
 
 ---
 
@@ -186,14 +186,14 @@ BinPackParameters: false
 - We'll talk about the other steps later
 
 
---- 
+---
 # An example is worth a 1000 words
 
 - An `#include` is just a _text_ substitution
 - Let's compile `hello.cpp` with a flag `--save-temps`:
     ```cmd
-    λ › c++ -std=c++17 -o hello --save-temps hello.cpp  
-    ``` 
+    λ › c++ -std=c++17 -o hello --save-temps hello.cpp
+    ```
 - This keeps a bunch of files, we care about `hello.ii`:
     ```cmd
     λ › tail -n 4 hello.ii
@@ -204,7 +204,7 @@ BinPackParameters: false
     ```
 - This file _ends_ with our program
 - Above our code there is the contents of the `stdio.h` file
---- 
+---
 
 # Let's get #inclusive
 
@@ -259,9 +259,9 @@ BinPackParameters: false
 - We can (and will!) write lots of our own functions
 - Let's write one right now!
 
---- 
+---
 # The `PrintSmth` function
-- This is **not** the most useful function in the world! 
+- This is **not** the most useful function in the world!
 - We also won't talk about a strict definition of what is a function here, we will cover it later
 - We aim at building intuition here!
 

--- a/lectures/more_useful_types.md
+++ b/lectures/more_useful_types.md
@@ -2,6 +2,7 @@
 marp: true
 math: katex
 theme: custom-theme
+paginate: true
 footer: ![width:80px](images/C++ForYourselfIcon.png)
 ---
 
@@ -14,11 +15,11 @@ We're gonna talk about it a lot!
 #### Today:
 - `std::pair`
 - `std::array`
-- `std::vector` 
+- `std::vector`
 - `std::string`
 - Aggregate initialization
 
-### 📺 Watch the related [YouTube video](https://youtu.be/dwkSVkGsvFk)! 
+### 📺 Watch the related [YouTube video](https://youtu.be/dwkSVkGsvFk)!
 
 ---
 # Prerequisites:
@@ -29,7 +30,7 @@ We're gonna talk about it a lot!
 ---
 
 # Disclaimer
-- This lecture is beginner friendly 
+- This lecture is beginner friendly
 - There are some best practices that would use different types, but those require more in-depth understanding and will be covered later
 - What you see on this slide is the best practice **until this point** in the course 😉
 
@@ -90,7 +91,7 @@ int main() {
 ```
 
 ---
-
+<!-- _paginate: false -->
 ![bg](https://fakeimg.pl/1280x1024/226699/fff/?text=STL%0ASequence%0Acontainers&font=bebas)
 
 ---
@@ -98,12 +99,12 @@ int main() {
 # Use `std::array` for fixed size collections of items of same type
 - 🔼1️⃣1️⃣ `#include <array>` to use [`std::array`](https://en.cppreference.com/w/cpp/container/array)
 - 🚨 The size must be known at compile time
-- Create from data: 
-  🔼1️⃣7️⃣ `std::array arr = {1, 2, 3};` 
-  🔼1️⃣7️⃣ `std::array arr{1, 2, 3};` 
-  🔼1️⃣4️⃣ `std::array<int, 3UL> arr{1, 2, 3};` 
-  🔼1️⃣1️⃣ `std::array<int, 3UL> arr = {1, 2, 3};` 
-  1️⃣1️⃣ `std::array<int, 3UL> arr{{1, 2, 3}};` 
+- Create from data:
+  🔼1️⃣7️⃣ `std::array arr = {1, 2, 3};`
+  🔼1️⃣7️⃣ `std::array arr{1, 2, 3};`
+  🔼1️⃣4️⃣ `std::array<int, 3UL> arr{1, 2, 3};`
+  🔼1️⃣1️⃣ `std::array<int, 3UL> arr = {1, 2, 3};`
+  1️⃣1️⃣ `std::array<int, 3UL> arr{{1, 2, 3}};`
   - In the newer standards, compiler guesses type and size
   - 🚨 Beware of double brackets in `C++11`!
 
@@ -134,10 +135,10 @@ int main() {
 - `#include <vector>` to use [`std::vector`](https://en.cppreference.com/w/cpp/container/vector)
 - Vector is implemented as a [**dynamic table**](https://en.wikipedia.org/wiki/Dynamic_array)
 - Create similarly to the `std::array`:
-  - 🔼1️⃣7️⃣ `std::vector vec{1, 2, 3};` 
-  - 🔼1️⃣7️⃣ `std::vector vec = {1, 2, 3};` 
-  - 🔼1️⃣1️⃣ `std::vector<int> vec{1, 2, 3};` 
-  - 🔼1️⃣1️⃣ `std::vector<int> vec = {1, 2, 3};` 
+  - 🔼1️⃣7️⃣ `std::vector vec{1, 2, 3};`
+  - 🔼1️⃣7️⃣ `std::vector vec = {1, 2, 3};`
+  - 🔼1️⃣1️⃣ `std::vector<int> vec{1, 2, 3};`
+  - 🔼1️⃣1️⃣ `std::vector<int> vec = {1, 2, 3};`
 - Access stored elements just like in `std::array`
   **But** we can also change the accessed values!
 - ✅ Use `std::vector` a lot! It is **fast and flexible**!
@@ -243,10 +244,10 @@ int main() {
 
 - Use [`std::to_string`](https://en.cppreference.com/w/cpp/string/basic_string/to_string) to convert variables of fundamental types to `std::string`
 - Use `std::sto[i|d|f|ul]` etc. to convert from strings:
-  - [`std::stoi`](https://en.cppreference.com/w/cpp/string/basic_string/stol) --- `std::string` $\rightarrow$ `int`
-  - [`std::stof`](https://en.cppreference.com/w/cpp/string/basic_string/stof) --- `std::string` $\rightarrow$ `float`
-  - [`std::stod`](https://en.cppreference.com/w/cpp/string/basic_string/stof) --- `std::string` $\rightarrow$ `double`
-  - [`std::stoul`](https://en.cppreference.com/w/cpp/string/basic_string/stoul) --- `std::string` $\rightarrow$ `unsigned long`
+  - [`std::stoi`](https://en.cppreference.com/w/cpp/string/basic_string/stol): `std::string` $\rightarrow$ `int`
+  - [`std::stof`](https://en.cppreference.com/w/cpp/string/basic_string/stof): `std::string` $\rightarrow$ `float`
+  - [`std::stod`](https://en.cppreference.com/w/cpp/string/basic_string/stof): `std::string` $\rightarrow$ `double`
+  - [`std::stoul`](https://en.cppreference.com/w/cpp/string/basic_string/stoul): `std::string` $\rightarrow$ `unsigned long`
   - There are more flavors (click the links :wink:)
 <!--
 `CPP_SETUP_START`
@@ -293,14 +294,14 @@ int another_number{std::stoi("42 is the number")};
   const std::vector vec_full_of_42(size, content);
 
   // 🚨 Using curly brackets creates vector with elements {10, 42}
-  const std::vector vec_10_and_42{size, content}; 
+  const std::vector vec_10_and_42{size, content};
   ```
 - ❌ `std::vector<bool>` is **weird**!
   **Reason:** it does _not_ behave like a `vector`, which is confusing
   Use only if you know that you're doing (probably don't)
 
 ---
-# 🔼1️⃣7️⃣ Aggregate initialization 
+# 🔼1️⃣7️⃣ Aggregate initialization
 - Used to initialize multiple variables at the same time
 - 🚨 We **must** use `auto`
 - Also supports `const` and references (`&`)
@@ -348,4 +349,8 @@ int another_number{std::stoi("42 is the number")};
 
 ---
 
+<!--
+_footer: ""
+_paginate: false
+-->
 ![bg](https://fakeimg.pl/1280x1024/226699/fff/?text=Good%20luck!&font=bebas)

--- a/theme.css
+++ b/theme.css
@@ -1,4 +1,6 @@
-/* @theme custom-theme */
+/* @theme custom-theme
+ * @auto-scaling false
+ */
 
 @import 'uncover';
 @import url('https://fonts.googleapis.com/css?family=Roboto:400,700&display=swap');
@@ -6,166 +8,182 @@
 
 
 :root {
-    font-family: 'Roboto';
-    text-align: left;
-    justify-content: flex-start;
-    line-height:1.5em;
-    letter-spacing: normal;
-    width: 1280px;
-    height: 1024px;
+  font-family: 'Roboto';
+  text-align: left;
+  justify-content: flex-start;
+  line-height: 1.4em;
+  letter-spacing: normal;
+  width: 1280px;
+  height: 1024px;
 }
 
 rect.label-container {
-    fill: #eeeeee;
-    stroke:#519EF0;
-    stroke-width:2px;
+  fill: #eeeeee;
+  stroke: #519EF0;
+  stroke-width: 2px;
+  filter: drop-shadow(2px 2px lightgray);
 }
 
 polygon.label-container {
-    fill: #eeeeee;
-    stroke:#519EF0;
-    stroke-width:2px;
+  fill: #eeeeee;
+  stroke: #519EF0;
+  stroke-width: 2px;
+  box-shadow: 10px 10px lightgray;
 }
 
 .label foreignObject {
-    overflow: visible;
-    display: flex;
-    padding: 2px;
+  overflow: visible;
+  display: flex;
+  padding: 2px;
 }
 
 span.nodeLabel {
-    color: black;
+  color: black;
 }
 
 .flowchart-link {
-    stroke: darkgray;
-    fill: darkgray;
-    stroke-width: 2px;
+  stroke: darkgray;
+  fill: darkgray;
+  stroke-width: 2px;
 }
 
 path {
-    stroke: darkgray;
-    fill: darkgray;
-    stroke-width: 2px;
+  stroke: darkgray;
+  fill: darkgray;
+  stroke-width: 2px;
 }
 
 span.edgeLabel {
-    background-color: white;
-    color: black;
+  background-color: white;
+  color: black;
 }
 
 svg {
-    zoom: 1.8;
+  zoom: 1.8;
+  line-height: 100%;
 }
 
 code {
-    font-family: 'Fira Mono', monospace !important;
-    font-weight: 500;
-    line-height: 1.15em;
-    padding-top: 3px;
-    padding-left: 5px;
-    padding-right: 5px;
-    padding-bottom: 3px;
-    margin-left: 2px;
-    margin-right: 2px;
+  font-family: 'Fira Mono', monospace !important;
+  box-shadow: 2px 2px lightgray;
+  font-size: 70%;
+  font-weight: 500;
+  line-height: 1.3em;
+  padding-top: 3px;
+  padding-left: 5px;
+  padding-right: 5px;
+  padding-bottom: 3px;
+  margin-top: 0.2em;
+  margin-left: 0.1em;
+  margin-bottom: 0.5em;
 }
 
 pre {
-    display: inline-block;
-    margin-left: 0.5em;
-    margin-bottom: 0.5em;
-    box-shadow: none;
-    outline: auto;
-    width: fit-content;
-    outline-color: #519EF0;
+  --preserve-aspect-ratio: xLeftYTop meet;
+
+  filter: none;
+  padding-left: 5px;
+  margin-top: 0.2em;
+  margin-left: 0.1em;
+  margin-bottom: 0.5em;
+  width: auto;
+  font-size: 80%;
 }
 
 footer {
-    text-align: right;
-    position: absolute;
-    bottom: 0em;
-    right: 1.5em;
+  text-align: left;
+  position: absolute;
+  bottom: 920px;
+  left: 1190px;
 }
 
 .grid-container {
-    display: grid;
-    grid-template-columns: 50% auto;
+  display: grid;
+  grid-template-columns: 50% auto;
 }
 
 blockquote p {
-    color: darkslategray;
-    text-align: right;
-    font-family: "Fira Code Medium";
+  color: darkslategray;
+  text-align: right;
+  font-family: "Fira Mono Medium";
 }
 
 header {
-    text-align: right;
-}
-
-svg {
-    line-height: 100%;
+  text-align: right;
 }
 
 h1 {
-    color: #519EF0;
-    padding-top: 0.4em;
-    margin-bottom: 0.2em;
-    font-size: 55pt;
-    line-height:1.2em;
+  color: #519EF0;
+  padding-top: 0.4em;
+  margin-bottom: 0.2em;
+  font-size: 55pt;
+  line-height: 1.2em;
 }
 
-h2, h3, h4, h5, h6 {
-    color: #226699;
-    margin-bottom: 0.2em;
-    margin-top: 0.5em;
-    letter-spacing: normal;
+h2,
+h3,
+h4,
+h5,
+h6 {
+  color: #226699;
+  margin-bottom: 0.2em;
+  margin-top: 0.5em;
+  letter-spacing: normal;
 }
 
-ul, ol {
-    margin-top: 0.2em;
-    margin-bottom: 0.2em;
-    margin-left: 0.2em;
+ul,
+ol {
+  margin-top: 0.2em;
+  margin-bottom: 0.2em;
+  margin-left: 0.2em;
 }
 
 kbd {
-    font-family: 'Fira Mono', monospace !important;
-    font-weight: 500;
-    background-color: rgba(0,0,0,0.05);
-    color: black;
-    padding-left: 0.3em;
-    padding-right: 0.3em;
-    margin-left: 0.1em;
-    margin-right: 0.2em;
-    box-shadow: 0.1em 0.1em 0em rgba(0,0,0,0.2);
+  font-family: 'Fira Mono', monospace !important;
+  font-weight: 500;
+  background-color: rgba(0, 0, 0, 0.05);
+  color: black;
+  padding-left: 0.3em;
+  padding-right: 0.3em;
+  margin-left: 0.1em;
+  margin-right: 0.2em;
+  box-shadow: 0.1em 0.1em 0em rgba(0, 0, 0, 0.2);
 }
 
 img[alt~="center"] {
-    display: block;
-    margin: 0 auto;
+  display: block;
+  margin: 0 auto;
 }
 
 section.white h1 {
-    color: white;
-    padding-left: 0.2em;
-    padding-right: 0.2em;
-    background-color: #519EF0;
+  color: white;
+  padding-left: 0.2em;
+  padding-right: 0.2em;
+  background-color: #519EF0;
+}
+
+section::after {
+  box-sizing: border-box;
+  text-align: center;
+  width: 120px;
+  height: 120px;
+  line-height: 0px;
+  color: gray;
+  background: linear-gradient(-45deg, rgba(0, 0, 0, 0.05) 50%, transparent 50%);
+  background-size: cover;
 }
 
 section.center_code pre {
-    align-items: center;
-    align-self: center;
-    margin-left: auto;
-    position: absolute;
-    top: 50%;
-    -ms-transform: translateY(-50%);
-    transform: translateY(-50%);
+  --preserve-aspect-ratio: xMidYMid meet;
+  margin: 0.5em;
 }
 
 section.code_without_margins pre {
-    margin: 0.5em;
+  --preserve-aspect-ratio: xMidYMid meet;
+  margin: 0.5em;
 }
 
 a {
-    color: #519EF0;
-    text-decoration: underline dotted;
+  color: #519EF0;
+  text-decoration: underline dotted;
 }


### PR DESCRIPTION
After MARP got updated, the old slides (before I moved on to the new format) started to look off. This PR fixes that issue by updating the css style of the theme as well as some of the lecture markdown files.